### PR TITLE
fix: install detection, manual browse, and folder picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 Fan-made browser for Heroes of Might and Magic: Olden Era game data.
 Browse units, heroes, spells, artifacts, buildings, and 3D models without opening the game.
 
+> Builds are released only on this project's [Releases page](https://github.com/laszlo-gilanyi/OldenEraExplorer/releases). The in-app updater (since v1.0.2) pulls from the same place. If you have a build from anywhere else, it's not mine, and I don't recommend running it.
+
 ## What's the point?
 
 In-game, you can only see what's currently available to you - units in your army, heroes you own, skills offered at level-up, spells you've unlocked.

--- a/backend/src/API/Endpoints/FilesystemEndpoints.cs
+++ b/backend/src/API/Endpoints/FilesystemEndpoints.cs
@@ -95,16 +95,21 @@ public static class FilesystemEndpoints
 
         try
         {
+            // On Linux, .NET maps any dot-prefixed name to FileAttributes.Hidden by convention,
+            // but those are normal locations the user often needs (e.g. ~/.steam, ~/.local/share/Steam,
+            // ~/.var/app for Flatpak). Only filter Hidden on Windows, where the attribute is an
+            // explicit user/OS marker rather than a naming convention.
+            bool isWindows = OperatingSystem.IsWindows();
+
             foreach (var dir in Directory.GetDirectories(path))
             {
                 try
                 {
                     var info = new DirectoryInfo(dir);
-                    if ((info.Attributes & FileAttributes.Hidden) != 0 ||
-                        (info.Attributes & FileAttributes.System) != 0)
-                    {
+                    if ((info.Attributes & FileAttributes.System) != 0)
                         continue;
-                    }
+                    if (isWindows && (info.Attributes & FileAttributes.Hidden) != 0)
+                        continue;
 
                     entries.Add(new DirectoryEntryDto(
                         Id: dir,

--- a/backend/src/API/Services/AssetExtractionService.cs
+++ b/backend/src/API/Services/AssetExtractionService.cs
@@ -161,6 +161,15 @@ public class AssetExtractionService : IAssetExtractionService, IDisposable
                 throw new InvalidOperationException("Game path not configured. Please set the game path first.");
             }
 
+            if (!GameData.Services.GameLocator.IsValidDataDirectory(gamePath))
+            {
+                throw new InvalidOperationException(
+                    $"Asset extraction requires Unity asset bundles (sharedassets*.assets and resources.assets) in '{gamePath}', " +
+                    "but they are missing. This usually means the install is incomplete or this is a leftover folder. " +
+                    "Reinstall the game or point Browse at the correct install. " +
+                    "JSON data browsing still works without bundles.");
+            }
+
             if (!request.ForceReExtract)
             {
                 try
@@ -651,14 +660,29 @@ public class AssetExtractionService : IAssetExtractionService, IDisposable
             var streamingAssets = Path.Combine(job.GamePath, "StreamingAssets");
             var coreZip = Path.Combine(streamingAssets, "Core.zip");
 
+            int sharedAssetsCount = 0;
+            bool hasResourcesAssets = false;
+            try
+            {
+                if (Directory.Exists(job.GamePath))
+                {
+                    sharedAssetsCount = Directory.EnumerateFiles(job.GamePath, "sharedassets*.assets",
+                        SearchOption.TopDirectoryOnly).Count();
+                    hasResourcesAssets = File.Exists(Path.Combine(job.GamePath, "resources.assets"));
+                }
+            }
+            catch { }
+
             _logger.LogInformation(
                 "Pre-flight: Executable={ExePath} (exists={ExeExists}, size={ExeSize:N0}, execBit={ExecBit}); " +
                 "OutputPath={OutputPath} (exists={OutExists}, writable={OutWritable}{WriteError}); " +
-                "GamePath={GamePath} (exists={GameExists}, hasStreamingAssets={HasSA}, hasCoreZip={HasCore}); " +
+                "GamePath={GamePath} (exists={GameExists}, hasStreamingAssets={HasSA}, hasCoreZip={HasCore}, " +
+                "sharedAssetsCount={SharedAssetsCount}, hasResourcesAssets={HasResourcesAssets}); " +
                 "FreeDisk={FreeDisk}",
                 _executablePath, execExists, execSize, execBit,
                 job.OutputPath, Directory.Exists(job.OutputPath), outputWritable, writeError,
                 job.GamePath, Directory.Exists(job.GamePath), Directory.Exists(streamingAssets), File.Exists(coreZip),
+                sharedAssetsCount, hasResourcesAssets,
                 FormatFreeDisk(job.OutputPath));
         }
         catch (Exception ex)

--- a/backend/src/API/Services/GamePathService.cs
+++ b/backend/src/API/Services/GamePathService.cs
@@ -24,7 +24,9 @@ public record SetPathResult(
     string? Error,
     string? GameRoot,
     string? HeroesOeDataPath,
-    string? StreamingAssetsPath
+    string? StreamingAssetsPath,
+    bool HasAssetBundles = true,
+    string? Warning = null
 );
 
 public interface IGamePathService
@@ -235,21 +237,23 @@ public class GamePathService : IGamePathService
 
             if (string.IsNullOrEmpty(streamingAssets))
             {
-                _logger.LogWarning("Path validation failed: no valid StreamingAssets found at {Path}", normalizedPath);
+                var errorMessage = BuildPathRejectionMessage(normalizedPath, locale);
+                _logger.LogWarning("Path validation failed: {Reason} (path: {Path})", errorMessage, normalizedPath);
                 return new SetPathResult(
                     Success: false,
-                    Error: "No valid StreamingAssets directory found. Ensure the path contains Core.zip and Lang/<locale>/texts/*.json",
+                    Error: errorMessage,
                     GameRoot: null,
                     HeroesOeDataPath: null,
                     StreamingAssetsPath: null
                 );
             }
 
-            var resolvedGameRoot = ResolveGameRootFromStreamingAssets(streamingAssets) ?? normalizedPath;
-
             var previousGameRoot = _gameRoot;
 
-            _gameRoot = resolvedGameRoot;
+            // Persist exactly what the caller picked so a manual browse to a *_Data or
+            // StreamingAssets dir is visibly reflected in the UI (acts as override confirmation).
+            // Auto-detect already passes a game root, so its display is unchanged.
+            _gameRoot = normalizedPath;
             _heroesOeDataPath = heroesOeData;
             _streamingAssetsPath = streamingAssets;
             _currentLocale = locale;
@@ -270,12 +274,27 @@ public class GamePathService : IGamePathService
 
             OnPathChanged(previousGameRoot, _gameRoot);
 
+            bool hasBundles = !string.IsNullOrEmpty(_heroesOeDataPath) &&
+                              GameLocator.IsValidDataDirectory(_heroesOeDataPath);
+            string? warning = hasBundles
+                ? null
+                : "This install has no Unity asset bundles (sharedassets*.assets / resources.assets), " +
+                  "so JSON data browsing works but image and 3D model extraction will not. " +
+                  "This usually means an incomplete install or a leftover folder.";
+
+            if (warning != null)
+            {
+                _logger.LogWarning("Path accepted but asset bundles missing in {DataPath}", _heroesOeDataPath);
+            }
+
             return new SetPathResult(
                 Success: true,
                 Error: null,
                 GameRoot: _gameRoot,
                 HeroesOeDataPath: _heroesOeDataPath,
-                StreamingAssetsPath: _streamingAssetsPath
+                StreamingAssetsPath: _streamingAssetsPath,
+                HasAssetBundles: hasBundles,
+                Warning: warning
             );
         }
     }
@@ -299,6 +318,29 @@ public class GamePathService : IGamePathService
         }
     }
 
+    private static string BuildPathRejectionMessage(string gameRoot, string locale)
+    {
+        try
+        {
+            if (!Directory.Exists(gameRoot))
+                return $"Directory does not exist: {gameRoot}";
+
+            var dataDirs = GameLocator.EnumerateDataDirsPreferringEA(gameRoot);
+            bool isDataDirItself = Path.GetFileName(gameRoot).EndsWith("_Data", StringComparison.OrdinalIgnoreCase);
+
+            if (dataDirs.Count == 0 && !isDataDirItself)
+            {
+                return "No *_Data directory found. Point this at the game's install root (the folder containing HeroesOldenEra.exe).";
+            }
+
+            return "No Core.zip or Lang folder found. The selected install looks empty or corrupted; reinstall the game or point Browse at the correct folder.";
+        }
+        catch
+        {
+            return "Could not validate the selected folder as a Heroes Olden Era install.";
+        }
+    }
+
     private static string? FindHeroesOeDataPath(string gameRoot)
     {
         if (string.IsNullOrEmpty(gameRoot) || !Directory.Exists(gameRoot))
@@ -306,42 +348,13 @@ public class GamePathService : IGamePathService
 
         try
         {
-            if (Path.GetFileName(gameRoot).Equals("HeroesOE_Data", StringComparison.OrdinalIgnoreCase))
+            if (Path.GetFileName(gameRoot).EndsWith("_Data", StringComparison.OrdinalIgnoreCase))
             {
                 return gameRoot;
             }
 
-            var heroesDataPath = Path.Combine(gameRoot, "HeroesOE_Data");
-            if (Directory.Exists(heroesDataPath))
-            {
-                return heroesDataPath;
-            }
-
-            var dataDirectories = Directory.GetDirectories(gameRoot, "*_Data");
-            var heroesData = dataDirectories.FirstOrDefault(d =>
-                Path.GetFileName(d).EndsWith("_Data", StringComparison.OrdinalIgnoreCase));
-
-            return heroesData;
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private static string? ResolveGameRootFromStreamingAssets(string streamingAssetsPath)
-    {
-        try
-        {
-            var parent = Directory.GetParent(streamingAssetsPath);
-            if (parent == null) return null;
-
-            if (parent.Name.EndsWith("_Data", StringComparison.OrdinalIgnoreCase))
-            {
-                return parent.Parent?.FullName;
-            }
-
-            return parent.FullName;
+            var ordered = GameLocator.EnumerateDataDirsPreferringEA(gameRoot);
+            return ordered.FirstOrDefault(GameLocator.IsValidDataDirectory) ?? ordered.FirstOrDefault();
         }
         catch
         {

--- a/backend/src/AssetExtractor/Pipeline/GamePathDetector.cs
+++ b/backend/src/AssetExtractor/Pipeline/GamePathDetector.cs
@@ -101,20 +101,58 @@ public sealed class GamePathDetector
             if (!Directory.Exists(path))
                 return null;
 
-            // If path itself is a *_Data directory, use it directly
             if (Path.GetFileName(path).EndsWith("_Data", StringComparison.OrdinalIgnoreCase))
             {
                 return ValidateDataDirectory(path) ? path : null;
             }
 
-            // Check for any *_Data subdirectory
-            var dataDir = Directory.EnumerateDirectories(path, "*_Data", SearchOption.TopDirectoryOnly)
-                .FirstOrDefault(d => ValidateDataDirectory(d));
-            return dataDir;
+            // EA-preferred ordering keeps an empty leftover HeroesOE_Data from shadowing
+            // the real HeroesOldenEra_Data when both exist side by side.
+            return EnumerateDataDirsPreferringEA(path)
+                .FirstOrDefault(ValidateDataDirectory);
         }
         catch
         {
             return null;
+        }
+    }
+
+    /// <summary>
+    /// Return *_Data subdirectories of gameRoot, ordered so a bundle-rich EA folder wins
+    /// over leftovers. Tier 1: bundles present, EA > demo > other. Tier 2: bundles missing,
+    /// EA > demo > other. Bundle-missing dirs are still returned so data browsing works.
+    /// </summary>
+    private List<string> EnumerateDataDirsPreferringEA(string gameRoot)
+    {
+        var dirs = new List<string>();
+        try
+        {
+            dirs.AddRange(Directory.EnumerateDirectories(gameRoot, "*_Data", SearchOption.TopDirectoryOnly));
+        }
+        catch { return dirs; }
+
+        dirs.Sort((a, b) =>
+        {
+            int ra = Rank(a);
+            int rb = Rank(b);
+            if (ra != rb) return ra - rb;
+            return string.Compare(a, b, StringComparison.OrdinalIgnoreCase);
+        });
+        return dirs;
+
+        int Rank(string dir)
+        {
+            var name = Path.GetFileName(dir);
+            bool bundle = ValidateDataDirectory(dir);
+            bool ea = name.Equals("HeroesOldenEra_Data", StringComparison.OrdinalIgnoreCase);
+            bool oe = name.Equals("HeroesOE_Data", StringComparison.OrdinalIgnoreCase);
+
+            if (bundle && ea) return 0;
+            if (bundle && oe) return 1;
+            if (bundle) return 2;
+            if (ea) return 3;
+            if (oe) return 4;
+            return 5;
         }
     }
 
@@ -339,8 +377,7 @@ public sealed class GamePathDetector
             if (!dirNameLower.Contains("olden") && !dirNameLower.Contains("heroes"))
                 return null;
 
-            var dataPath = Directory.EnumerateDirectories(directory, "*_Data", SearchOption.TopDirectoryOnly)
-                .FirstOrDefault();
+            var dataPath = EnumerateDataDirsPreferringEA(directory).FirstOrDefault();
             if (dataPath is null)
                 return null;
 

--- a/backend/src/GameData/Services/GameLocator.cs
+++ b/backend/src/GameData/Services/GameLocator.cs
@@ -35,9 +35,12 @@ public static class GameLocator
             try { p = Path.GetFullPath(p); } catch { }
             if (!Directory.Exists(p)) return "";
 
+            // Acceptance is gated only by Core.zip + Lang. Asset bundles are intentionally
+            // NOT required here: JSON data browsing must work on installs that lack
+            // sharedassets/resources.assets. Extraction has its own bundle check at start-time.
             var candidates = new List<string>();
 
-            if (Directory.Exists(Path.Combine(p, "Lang")))
+            if (Directory.Exists(Path.Combine(p, "Lang")) || FindCoreZip(p) != null)
                 candidates.Add(p);
 
             if (p.EndsWith("_Data", StringComparison.OrdinalIgnoreCase))
@@ -46,8 +49,7 @@ public static class GameLocator
                 if (Directory.Exists(sa)) candidates.Add(sa);
             }
 
-            var dataDir = Directory.EnumerateDirectories(p, "*_Data", SearchOption.TopDirectoryOnly).FirstOrDefault();
-            if (dataDir is not null)
+            foreach (var dataDir in EnumerateDataDirsPreferringEA(p))
             {
                 var sa = Path.Combine(dataDir, "StreamingAssets");
                 if (Directory.Exists(sa)) candidates.Add(sa);
@@ -66,6 +68,75 @@ public static class GameLocator
         }
     }
 
+    /// <summary>
+    /// True if the given *_Data directory contains the Unity asset bundles required for extraction.
+    /// Demo/EA leftovers with only Core.zip and lang files will fail this check.
+    /// </summary>
+    public static bool IsValidDataDirectory(string dataDir)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(dataDir) || !Directory.Exists(dataDir)) return false;
+            if (!Directory.EnumerateFiles(dataDir, "sharedassets*.assets", SearchOption.TopDirectoryOnly).Any())
+                return false;
+            if (!File.Exists(Path.Combine(dataDir, "resources.assets")))
+                return false;
+            return true;
+        }
+        catch { return false; }
+    }
+
+    /// <summary>
+    /// Return *_Data subdirectories of gameRoot, ordered so a bundle-rich EA folder wins
+    /// over leftovers. Sort key: bundle-present beats bundle-missing; within each tier, EA
+    /// (HeroesOldenEra_Data) beats demo (HeroesOE_Data) beats others (alphabetical).
+    /// Bundle-missing dirs are still returned: data browsing should work even on incomplete installs.
+    /// </summary>
+    public static List<string> EnumerateDataDirsPreferringEA(string gameRoot)
+    {
+        var dirs = new List<string>();
+        try
+        {
+            dirs.AddRange(Directory.EnumerateDirectories(gameRoot, "*_Data", SearchOption.TopDirectoryOnly));
+        }
+        catch { return dirs; }
+
+        dirs.Sort((a, b) =>
+        {
+            int ra = Rank(a);
+            int rb = Rank(b);
+            if (ra != rb) return ra - rb;
+            return string.Compare(a, b, StringComparison.OrdinalIgnoreCase);
+        });
+        return dirs;
+
+        static int Rank(string dir)
+        {
+            var name = Path.GetFileName(dir);
+            bool bundle = IsValidDataDirectory(dir);
+            bool ea = name.Equals("HeroesOldenEra_Data", StringComparison.OrdinalIgnoreCase);
+            bool oe = name.Equals("HeroesOE_Data", StringComparison.OrdinalIgnoreCase);
+
+            if (bundle && ea) return 0;
+            if (bundle && oe) return 1;
+            if (bundle) return 2;
+            if (ea) return 3;
+            if (oe) return 4;
+            return 5;
+        }
+    }
+
+    private static string? FindCoreZip(string streamingAssets)
+    {
+        try
+        {
+            // Case-insensitive lookup so "core.zip" works on Linux too.
+            return Directory.EnumerateFiles(streamingAssets, "*.zip", SearchOption.TopDirectoryOnly)
+                .FirstOrDefault(f => Path.GetFileName(f).Equals("Core.zip", StringComparison.OrdinalIgnoreCase));
+        }
+        catch { return null; }
+    }
+
     public static bool IsValidStreamingAssets(string? streamingAssets, string preferredLocale)
     {
         try
@@ -74,8 +145,8 @@ public static class GameLocator
             var root = streamingAssets!;
             if (!Directory.Exists(root)) return false;
 
-            var coreZip = Path.Combine(root, "Core.zip");
-            if (!File.Exists(coreZip)) return false;
+            var coreZip = FindCoreZip(root);
+            if (coreZip is null) return false;
 
             // Demo: Lang is on disk
             foreach (var loc in BuildLocaleProbeOrder(preferredLocale))
@@ -151,12 +222,10 @@ public static class GameLocator
         try
         {
             string? streamingAssets = null;
-
-            var dataDir = Directory.EnumerateDirectories(gameRoot, "*_Data", SearchOption.TopDirectoryOnly).FirstOrDefault();
-            if (dataDir is not null)
+            foreach (var dataDir in EnumerateDataDirsPreferringEA(gameRoot))
             {
                 var sa = Path.Combine(dataDir, "StreamingAssets");
-                if (Directory.Exists(sa)) streamingAssets = sa;
+                if (Directory.Exists(sa)) { streamingAssets = sa; break; }
             }
 
             if (streamingAssets is null)
@@ -190,8 +259,8 @@ public static class GameLocator
             // EA: Lang inside Core.zip
             if (!localeOk)
             {
-                var coreZip = Path.Combine(streamingAssets, "Core.zip");
-                if (File.Exists(coreZip))
+                var coreZip = FindCoreZip(streamingAssets);
+                if (coreZip is not null)
                 {
                     try
                     {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ function App() {
 
   const { data: gameStatus, isLoading: gameStatusLoading } = useGameStatus();
   const setGameReady = useGameStore((state) => state.setGameReady);
+  const isGameReady = useGameStore((state) => state.isGameReady);
 
   // API client request interceptor blocks calls when game not ready, so sync this state
   useEffect(() => {
@@ -147,8 +148,11 @@ function App() {
     return <LoadingScreen message={loadingMessage} />;
   }
 
-  // Child routes expect game data to be available - show loading until ready to prevent API errors
-  if (!gameStatus?.dataLoaded) {
+  // Both flags must agree: dataLoaded comes from the query, isGameReady is the Zustand
+  // mirror the API interceptor reads, and that mirror is set in a useEffect (one render
+  // late). Without checking both, a quick click during that one frame triggers a spurious
+  // "game data not loaded" error from the interceptor.
+  if (!gameStatus?.dataLoaded || !isGameReady) {
     return <LoadingScreen message={label('loading_game_data')} />;
   }
   return (

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -66,13 +66,15 @@ api.interceptors.request.use((config) => {
 function handleApiError(error: unknown): never {
   if (axios.isAxiosError(error)) {
     const axiosError = error as AxiosError<ErrorDto>;
-    const message = axiosError.response?.data?.error || axiosError.message;
+    // Prefer `detail` (the user-facing explanation) over the short `error` label so the UI
+    // can show the actionable message instead of a generic "Extraction error".
+    const detail = axiosError.response?.data?.detail;
+    const shortError = axiosError.response?.data?.error;
+    const message = detail || shortError || axiosError.message;
     const method = (axiosError.config?.method ?? 'GET').toUpperCase();
     const path = axiosError.config?.url ?? '(unknown)';
     const status = axiosError.response?.status ?? 0;
     const body = axiosError.response?.data;
-    // Dev console mirror so non-OK API responses surface where developers look first.
-    // The thrown error still flows through React Query / mutations as before.
     console.error('[OldenEraExplorer] API error:', method, path, status, body ?? message);
     throw new Error(message);
   }

--- a/frontend/src/features/extraction/ExtractionPanel.tsx
+++ b/frontend/src/features/extraction/ExtractionPanel.tsx
@@ -74,6 +74,15 @@ export function AssetExtractionPanel() {
 
   const startMutation = useMutation({
     mutationFn: () => extractionApi.start({ extractPng, extractGlb, forceReExtract }),
+    onError: (error: Error) => {
+      // The backend rejects with 409/400 when extraction can't start (e.g. missing asset
+      // bundles). Surface the message in the same Failed/error panel that mid-run failures use.
+      const message = error.message || 'Failed to start extraction.';
+      useExtractionStore.getState().setError(message);
+      useExtractionStore.getState().setStatus('Failed');
+      setShowErrorPanel(true);
+      setPanelOpen(false);
+    },
   });
 
   const cancelMutation = useMutation({


### PR DESCRIPTION
- Auto-detect prefers the Early Access build over a leftover demo folder when both exist
- Empty data folders no longer block detection from finding the real install next to them 
- Accept installs without image and 3D model assets for data browsing; extraction shows a clear up-front error in the Failed panel instead of a cryptic mid-run failure 
- Manual browse persists the exact path you pick, so the override is visible in Settings
- Folder picker shows hidden dot-folders on Linux so Steam install paths are reachable; Windows unchanged 
- Fix startup race that could show "game data not loaded" on early clicks 
- Pre-flight log records asset bundle presence
- README: add an "official source" notice pointing to the Releases page and the in-app updater

Closes #10.